### PR TITLE
Add SonarQube Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,3 +54,11 @@ jacocoTestReport {
 		xml.outputLocation = file("$rootDir/reports/coverage.xml")
 	}
 }
+
+sonar {
+	properties {
+		property("sonar.projectKey", "Vulnerable-Java-App")
+		property("sonar.projectName", "Vulnerable Java App")
+		// add host URL and TOKEN in command line
+	}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 	id 'com.github.spotbugs' version '6.0.11'
 	id 'jacoco'
+	id 'org.sonarqube' version '5.0.0.4638'
 }
 
 group = 'com.datadoghq.workshops'


### PR DESCRIPTION
Adds the SonarQube Plugin so we can trigger an analysis using the [gradle task](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-gradle/).