### PR TITLE
Add alternative GitHub Workflows

### DIFF
--- a/.github/workflows/local-analysis.yaml
+++ b/.github/workflows/local-analysis.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - uses: gradle/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 8.9
       - name: build

--- a/.github/workflows/local-analysis.yaml
+++ b/.github/workflows/local-analysis.yaml
@@ -1,0 +1,32 @@
+name: "Codacy Local Analysis"
+
+on: push
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+      - name: build
+        run: gradle build
+      - name: generate coverage report
+        run: gradle jacocoTestReport
+      - name: uploade coverage data
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: reports/coverage.xml
+      - name: generate and upload local analysis data
+        uses: codacy/codacy-analysis-cli-action@v4.4.5
+        with: 
+          tool: spotbugs
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          upload: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: "Release and Attest"
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: insert newrelic key
+        run: sed -i "s|<LICENSE_KEY>|${{ secrets.NEWRELIC_LICENSE_KEY }}|g" newrelic.yml
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: type=semver,pattern={{version}}
+          images: codingdepot/idp-target-registry
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This PR adds GitHub workflow files to be used as an alternative to some Tekton Pipelines.
The following two Workflows are added:
 - **local-analysis**: matches the **analysis-pipeline** in Tekton, which creates both the coverage data and the local spotbugs analysis results and pushes them to Codacy
 - **release**: matches the **release-pipeline** in Tekton, which builds a Docker image and creates a SLSA attestation to verify the artifacts later

It is advised to enable *either* the GitHub workflows or the Tekton pipelines to prevent doubling the work done. The other Tekton pipelines can continue to be used considering the following:
 - **codacy-pipeline**: the pipeline that checks new PRs against Codacy Quality gates can continue to be used. However, as Codacy pushes its provider integrations more and more, this functionality could now be better fine-tuned using integrations in teh Codacy dashboard
 - **deploy-pipeline**: this pipeline triggers when a new image is published in DockerHub, checks the attestation of the image and updates the Kubernetes deployment to use the new version.

In order to enable or disable any Tekton Pipelines, it is advised to just delete the respective triggers that trigger the pipeline run from the GitHub webhook.