### PR TITLE
Set Attestation Registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: codingdepot/idp-target-registry
+          subject-name: docker.io/codingdepot/idp-target-registry
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
In the release workflow, specify docker.io as the target registry