### PR TITLE
Remove latest Tag from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           tags: type=semver,pattern={{version}}
+          flavor: latest=false
           images: codingdepot/idp-target-registry
       - name: Build and push
         id: push


### PR DESCRIPTION
Does not add the latest tag to the docker metadata as it is not necessary