### PR TITLE
Move Newrelic Downloads into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM gradle:7.5.1-jdk17 AS builder
+FROM gradle:8.9.0-jdk17 AS builder
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle downloadNewrelic && gradle unzipNewrelic
+RUN apt-get update && apt-get install -y unzip curl
+RUN curl -O https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip \
+        && unzip newrelic-java.zip
 RUN gradle bootJar --no-daemon
 
 FROM amazoncorretto:17-alpine

--- a/build.gradle
+++ b/build.gradle
@@ -35,14 +35,3 @@ jacocoTestReport {
 		xml.outputLocation = file("$rootDir/reports/coverage.xml")
 	}
 }
-
-task downloadNewrelic(type: Download) {
-    mkdir 'newrelic'
-    src 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip'
-    dest file('newrelic')
-}
-
-task unzipNewrelic(type: Copy) {
-    from zipTree(file('newrelic/newrelic-java.zip'))
-    into rootDir
-}


### PR DESCRIPTION
Remove gradle tasks that download and unzip newrelic agent and do this in the dockerfile instead.