### PR TITLE
Use Docker Build Path Context

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          context: .
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:


### PR DESCRIPTION
Use the Path Context in the docker build action.
Otherwise the repository is cloned fresh and previous changes (such as the inserted newrelic license key) are ignored.