### PR TITLE
Remove Download in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM gradle:8.9.0-jdk17 AS builder
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN apt-get update && apt-get install -y unzip curl
 RUN curl -O https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip \
         && unzip newrelic-java.zip
 RUN gradle bootJar --no-daemon


### PR DESCRIPTION
Remove redundant downloads in Dockerfile.
The packages are already included in the base image